### PR TITLE
fix: sort file names when specifying a directory

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -78,7 +78,7 @@ class Settings<T> {
       if (!(fs.existsSync(dir) && fs.lstatSync(dir).isDirectory())) {
         throw new Error(`'${dir}' not exists or is not a dir`);
       }
-      const filesInDirectory = fs.readdirSync(dir);
+      const filesInDirectory = fs.readdirSync(dir).sort();
 
       if (filesInDirectory.length === 0) {
         throw new Error(`Directory '${dir}' is empty`);
@@ -87,7 +87,7 @@ class Settings<T> {
         if (!Array.isArray(this.sourceFile)) {
           this.sourceFile = [];
         }
-        this.sourceFile.unshift(`${dir}/${file}`);
+        this.sourceFile.push(`${dir}/${file}`);
       });
     }
   }

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -1450,7 +1450,7 @@ describe("Settings", () => {
     });
 
     // eslint-disable-next-line jest/no-disabled-tests
-    describe.skip("if data has collisions on primitive values", () => {
+    describe("if data has collisions on primitive values", () => {
       it("should prioritize first loaded file", () => {
         const settings = new Settings(
           {
@@ -1483,7 +1483,7 @@ describe("Settings", () => {
     });
 
     // eslint-disable-next-line jest/no-disabled-tests
-    describe.skip("if data has collisions on objects", () => {
+    describe("if data has collisions on objects", () => {
       it("should prioritize first loaded file", () => {
         const settings = new Settings(
           {
@@ -1514,7 +1514,7 @@ describe("Settings", () => {
     });
 
     // eslint-disable-next-line jest/no-disabled-tests
-    describe.skip("if data has collisions on arrays", () => {
+    describe("if data has collisions on arrays", () => {
       it("should prioritize first loaded file", () => {
         const settings = new Settings(
           {


### PR DESCRIPTION
fix: sort file names when specifying a directory, to ensure consistency among platforms. fixes #23