### PR TITLE
feat: type-safe defaultValue for option factories

### DIFF
--- a/src/option/array.ts
+++ b/src/option/array.ts
@@ -1,15 +1,15 @@
-import type { ConfigFileData, Path } from "@/types";
+import type { ConfigFileData, Path, SchemaValue } from "@/types";
 import { InvalidValue } from "@/types";
 
 import type { OptionTypes } from ".";
 import ArrayValueContainer from "./arrayOption";
-import type { DefaultValue, Node, Value } from "./base";
+import type { Node, Value } from "./base";
 import OptionBase from "./base";
 import OptionErrors from "./errors";
 
 interface ArrayOptionClassParams<T extends Node | OptionTypes> {
   required: boolean;
-  defaultValue?: DefaultValue;
+  defaultValue?: SchemaValue<T>[] | (() => SchemaValue<T>[]);
   item: T;
 }
 export default class ArrayOption<

--- a/src/option/base.ts
+++ b/src/option/base.ts
@@ -1,7 +1,14 @@
 /* eslint-disable max-lines */
 import { loadConfigFile } from "@/fileLoader";
 import ConfigNode from "@/nodes/configNode";
-import type { ArrayValue, ConfigFileData, OptionKind, Path } from "@/types";
+import type {
+  ArrayValue,
+  ConfigFileData,
+  OptionKind,
+  Path,
+  PrimitiveKind,
+  TypeOfPrimitiveKind,
+} from "@/types";
 import { InvalidValue } from "@/types";
 import { valueIsInvalid } from "@/utils";
 
@@ -22,6 +29,10 @@ export type DefaultValue =
   | (() => number)
   | (() => boolean);
 
+export type TypedDefaultValue<T extends OptionKind> = T extends PrimitiveKind
+  ? TypeOfPrimitiveKind<T> | (() => TypeOfPrimitiveKind<T>)
+  : DefaultValue;
+
 type RecursiveNode<T> = { [key: string]: OptionBase | T };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -33,7 +44,7 @@ interface OptionClassParams<T extends OptionKind> {
   env: string | null;
   cli: boolean;
   help: string;
-  defaultValue?: DefaultValue;
+  defaultValue?: TypedDefaultValue<T>;
   // properties: {
   //   [key: string]: Option;
   // };

--- a/tests/type-tests/default-value-types.test-d.ts
+++ b/tests/type-tests/default-value-types.test-d.ts
@@ -1,0 +1,51 @@
+/**
+ * Compile-time type tests for type-safe defaultValue.
+ *
+ * These tests verify that the TypeScript compiler rejects invalid
+ * defaultValue types. They are NOT meant to be executed — only type-checked.
+ *
+ * Run: npm run type-check
+ *
+ * If any @ts-expect-error line does NOT produce an error, tsc will fail,
+ * proving that the type constraint is working.
+ */
+
+import c from "@/src";
+
+// --- Valid usage (should compile) ---
+
+c.string({ defaultValue: "hello" });
+c.string({ defaultValue: () => "hello" });
+c.number({ defaultValue: 42 });
+c.number({ defaultValue: () => 42 });
+c.bool({ defaultValue: true });
+c.bool({ defaultValue: () => false });
+c.array({ item: c.string(), defaultValue: ["a", "b"] });
+c.array({ item: c.string(), defaultValue: () => ["a", "b"] });
+c.array({ item: c.number(), defaultValue: [1, 2] });
+
+// --- Invalid usage (should NOT compile) ---
+
+// @ts-expect-error — number is not assignable to string defaultValue
+c.string({ defaultValue: 123 });
+
+// @ts-expect-error — boolean is not assignable to string defaultValue
+c.string({ defaultValue: true });
+
+// @ts-expect-error — string is not assignable to number defaultValue
+c.number({ defaultValue: "None" });
+
+// @ts-expect-error — boolean is not assignable to number defaultValue
+c.number({ defaultValue: false });
+
+// @ts-expect-error — string is not assignable to boolean defaultValue
+c.bool({ defaultValue: "yes" });
+
+// @ts-expect-error — number is not assignable to boolean defaultValue
+c.bool({ defaultValue: 1 });
+
+// @ts-expect-error — number[] is not assignable to string[] defaultValue
+c.array({ item: c.string(), defaultValue: [1, 2] });
+
+// @ts-expect-error — string[] is not assignable to number[] defaultValue
+c.array({ item: c.number(), defaultValue: ["a", "b"] });


### PR DESCRIPTION
## Summary
- `c.number({ defaultValue: 'None' })` is now a compile-time error
- `c.string({ defaultValue: 42 })` is now a compile-time error
- `c.bool({ defaultValue: 'yes' })` is now a compile-time error
- `c.array({ item: c.string(), defaultValue: [1, 2] })` is now a compile-time error
- Added `TypedDefaultValue<T>` utility type that maps option kind to the correct TypeScript type
- Array `defaultValue` now uses `SchemaValue<T>[]` for proper recursive type checking
- Includes compile-time test file (`tests/type-tests/default-value-types.test-d.ts`) using `@ts-expect-error` directives

## Test plan
- [x] All 84 tests pass
- [x] Lint and type-check clean
- [x] Compile-time tests verify invalid defaults are rejected

Addresses #33 (part 1: per-option defaultValue type safety)