### PR TITLE
feat!: remove dead option kinds for v2.0.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,17 +19,12 @@ interface ArrayOptionPropsArgs<T extends Node | OptionTypes> {
   item: T;
   defaultValue?: SchemaValue<T>[] | (() => SchemaValue<T>[]);
 }
-// interface ObjectOptionPropsArgs {
-//   required?: boolean;
-//   item: Node;
-// }
 
 const DEFAULTS = {
   required: false,
   env: null,
   cli: false,
   help: "",
-  // properties: {},
 };
 
 const string = (opts?: OptionPropsArgs<string>): PrimitiveOption<"string"> => {
@@ -61,12 +56,6 @@ const array = <T extends Node | OptionTypes>(
     ...opts,
   });
 };
-// const object = (opts: ObjectOptionPropsArgs): ObjectOption => {
-//   return new ObjectOption({
-//     ...DEFAULTS,
-//     ...opts,
-//   });
-// };
 
 const schema = <T extends Node>(theSchema: T): SettingsBuilder<T> => {
   return new SettingsBuilder(theSchema);
@@ -76,7 +65,6 @@ const option = {
   string,
   number,
   bool,
-  // object,
   array,
   schema,
 };

--- a/src/option/base.ts
+++ b/src/option/base.ts
@@ -320,16 +320,13 @@ export default class OptionBase<T extends OptionKind = OptionKind> {
     if (this.params.kind === "number") {
       return this.checkNumberType(val, ident, sourceOfVal);
     }
-    if (this.params.kind === "any") {
-      return val;
-    }
     OptionErrors.errors.push({
       message: `Invalid state. Invalid kind in ${sourceOfVal}`,
       source: sourceOfVal,
       kind: "invalid_state",
     });
     throw new Error(
-      "Invalid kind. Must be 'string', 'number', 'boolean', 'array' or 'any'"
+      "Invalid kind. Must be 'string', 'number', 'boolean' or 'array'"
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,13 +19,7 @@ export type SettingsSources<T> = {
   exitOnError?: boolean;
 };
 
-export type OptionKind =
-  | "boolean"
-  | "string"
-  | "number"
-  | "any"
-  | "array"
-  | "object";
+export type OptionKind = "boolean" | "string" | "number" | "array";
 
 export type PrimitiveKind = Extract<
   OptionKind,

--- a/tests/option.spec.ts
+++ b/tests/option.spec.ts
@@ -2,7 +2,6 @@ import ConfigNode from "@/nodes/configNode";
 import {
   ArrayOption,
   ArrayValueContainer,
-  OptionBase,
   OptionErrors,
   PrimitiveOption,
 } from "@/option";
@@ -338,29 +337,6 @@ describe("option", () => {
     });
   });
 
-  describe("if the option kind is any", () => {
-    it("should return the value", () => {
-      const option = new OptionBase({
-        kind: "any",
-        required: false,
-        env: null,
-        cli: false,
-        help: "",
-      });
-      const value = option.getValue(FILE, ENV, {}, ["test", "any"]);
-      expect(value).toEqual(
-        new ConfigNode(
-          {},
-          "test.any",
-          "file",
-          "./tests/__mocks__/fileMock.yaml",
-          null,
-          null
-        )
-      );
-    });
-  });
-
   describe("if the option kind is not supported", () => {
     it("should save an error", () => {
       const option = new PrimitiveOption({
@@ -373,7 +349,7 @@ describe("option", () => {
       });
       expect(() => option.getValue(FILE, ENV, {}, ["test", "any"])).toThrow(
         new Error(
-          "Invalid kind. Must be 'string', 'number', 'boolean', 'array' or 'any'"
+          "Invalid kind. Must be 'string', 'number', 'boolean' or 'array'"
         )
       );
       expect(OptionErrors.errors).toContainEqual(


### PR DESCRIPTION
## Summary
- Removes `"any"` and `"object"` from the `OptionKind` type union — these were never exposed via the public API factories and had no runtime usage
- Removes the dead `"any"` handler code path in `OptionBase.checkType()`
- Removes commented-out `ObjectOption` code from `src/index.ts`
- Cleans up the corresponding test case and unused `OptionBase` import in tests

## BREAKING CHANGE
`OptionKind` no longer includes `"any"` or `"object"`. Any code directly referencing these values will need to be updated.

## Test plan
- [x] `yarn test` — 83 tests pass
- [x] `yarn type-check` — no errors
- [x] `yarn lint` — no warnings