### PR TITLE
feat!: v2 breaking changes — option.object() and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,25 @@ import c from "@meltstudio/config-loader";
 const config = c
   .schema({
     port: c.number({ required: true, env: "PORT" }),
-    database: {
-      host: c.string({ required: true }),
-      credentials: {
-        username: c.string(),
-        password: c.string({ env: "DB_PASSWORD" }),
+    database: c.object({
+      item: {
+        host: c.string({ required: true }),
+        credentials: c.object({
+          item: {
+            username: c.string(),
+            password: c.string({ env: "DB_PASSWORD" }),
+          },
+        }),
       },
-    },
+    }),
     features: c.array({
       required: true,
-      item: {
-        name: c.string(),
-        enabled: c.bool(),
-      },
+      item: c.object({
+        item: {
+          name: c.string(),
+          enabled: c.bool(),
+        },
+      }),
     }),
   })
   .load({
@@ -99,33 +105,41 @@ import c from "@meltstudio/config-loader";
 const config = c
   .schema({
     version: c.string({ required: true, cli: true }),
-    website: {
-      title: c.string({ required: true }),
-      url: c.string({
-        required: false,
-        defaultValue: "www.mywebsite.dev",
-      }),
-      description: c.string({ required: true }),
-      isProduction: c.bool({ required: true }),
-    },
-    database: {
-      host: c.string({ required: true }),
-      port: c.number({ required: true }),
-      credentials: {
-        username: c.string(),
-        password: c.string(),
+    website: c.object({
+      item: {
+        title: c.string({ required: true }),
+        url: c.string({
+          required: false,
+          defaultValue: "www.mywebsite.dev",
+        }),
+        description: c.string({ required: true }),
+        isProduction: c.bool({ required: true }),
       },
-    },
+    }),
+    database: c.object({
+      item: {
+        host: c.string({ required: true }),
+        port: c.number({ required: true }),
+        credentials: c.object({
+          item: {
+            username: c.string(),
+            password: c.string(),
+          },
+        }),
+      },
+    }),
     socialMedia: c.array({
       required: true,
       item: c.string({ required: true }),
     }),
     features: c.array({
       required: true,
-      item: {
-        name: c.string(),
-        enabled: c.bool(),
-      },
+      item: c.object({
+        item: {
+          name: c.string(),
+          enabled: c.bool(),
+        },
+      }),
     }),
   })
   .load({
@@ -182,29 +196,50 @@ c.number({ required: true, env: "PORT" });
 c.bool({ env: "DEBUG", defaultValue: false });
 ```
 
+### Objects
+
+Use `c.object()` to declare nested object schemas:
+
+```typescript
+c.object({
+  item: {
+    host: c.string(),
+    port: c.number(),
+  },
+});
+```
+
+Objects can be nested arbitrarily deep:
+
+```typescript
+c.schema({
+  database: c.object({
+    item: {
+      host: c.string(),
+      port: c.number(),
+      credentials: c.object({
+        item: {
+          username: c.string(),
+          password: c.string({ env: "DB_PASSWORD" }),
+        },
+      }),
+    },
+  }),
+});
+```
+
+`c.object()` accepts a `required` option (defaults to `false`). When the entire subtree is absent from all sources, child `required` options will trigger errors through normal validation.
+
 ### Arrays
 
 ```typescript
 c.array({ required: true, item: c.string() }); // string[]
 c.array({ required: true, item: c.number() }); // number[]
-c.array({ item: { name: c.string(), age: c.number() } }); // { name: string; age: number }[]
-```
-
-### Nested objects
-
-Just use plain objects — no wrapper needed:
-
-```typescript
-c.schema({
-  database: {
-    host: c.string(),
-    port: c.number(),
-    credentials: {
-      username: c.string(),
-      password: c.string({ env: "DB_PASSWORD" }),
-    },
-  },
-});
+c.array({
+  item: c.object({
+    item: { name: c.string(), age: c.number() },
+  }),
+}); // { name: string; age: number }[]
 ```
 
 ## Loading Sources
@@ -308,9 +343,11 @@ Set `env: "VAR_NAME"` on an option and `env: true` in the load options:
 
 ```typescript
 c.schema({
-  database: {
-    password: c.string({ env: "DB_PASSWORD" }),
-  },
+  database: c.object({
+    item: {
+      password: c.string({ env: "DB_PASSWORD" }),
+    },
+  }),
 }).load({ env: true, args: false, files: "./config.yaml" });
 ```
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -5,36 +5,44 @@ import c from "@/src";
 const run = (): void => {
   const settings = c.schema({
     version: c.string({ required: true, cli: true }),
-    website: {
-      title: c.string({ required: true }),
-      url: c.string({
-        required: false,
-        defaultValue: "www.mywebsite.dev",
-      }),
-      description: c.string({ required: true }),
-      isProduction: c.bool({ required: true }),
-    },
-    database: {
-      host: c.string({ required: true }),
-      port: c.number({ required: true }),
-      credentials: {
-        username: c.string(),
-        password: c.string({
-          env: "DB_PASSWORD",
-          cli: true,
+    website: c.object({
+      item: {
+        title: c.string({ required: true }),
+        url: c.string({
+          required: false,
+          defaultValue: "www.mywebsite.dev",
+        }),
+        description: c.string({ required: true }),
+        isProduction: c.bool({ required: true }),
+      },
+    }),
+    database: c.object({
+      item: {
+        host: c.string({ required: true }),
+        port: c.number({ required: true }),
+        credentials: c.object({
+          item: {
+            username: c.string(),
+            password: c.string({
+              env: "DB_PASSWORD",
+              cli: true,
+            }),
+          },
         }),
       },
-    },
+    }),
     socialMedia: c.array({
       required: true,
       item: c.string({ required: true }),
     }),
     features: c.array({
       required: true,
-      item: {
-        name: c.string(),
-        enabled: c.bool(),
-      },
+      item: c.object({
+        item: {
+          name: c.string(),
+          enabled: c.bool(),
+        },
+      }),
     }),
   });
   const config = settings.load({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { SettingsBuilder } from "@/builder";
 
 import type { Node, OptionTypes } from "./option";
-import { ArrayOption, PrimitiveOption } from "./option";
+import { ArrayOption, ObjectOption, PrimitiveOption } from "./option";
 import type { SchemaValue } from "./types";
 
 export type { ConfigErrorEntry } from "./errors";
@@ -14,10 +14,14 @@ interface OptionPropsArgs<T> {
   defaultValue?: T | (() => T);
   help?: string;
 }
-interface ArrayOptionPropsArgs<T extends Node | OptionTypes> {
+interface ArrayOptionPropsArgs<T extends OptionTypes> {
   required?: boolean;
   item: T;
   defaultValue?: SchemaValue<T>[] | (() => SchemaValue<T>[]);
+}
+interface ObjectOptionPropsArgs<T extends Node> {
+  required?: boolean;
+  item: T;
 }
 
 const DEFAULTS = {
@@ -48,11 +52,19 @@ const bool = (opts?: OptionPropsArgs<boolean>): PrimitiveOption<"boolean"> => {
     ...opts,
   });
 };
-const array = <T extends Node | OptionTypes>(
+const array = <T extends OptionTypes>(
   opts: ArrayOptionPropsArgs<T>
 ): ArrayOption<T> => {
   return new ArrayOption<T>({
     ...DEFAULTS,
+    ...opts,
+  });
+};
+const object = <T extends Node>(
+  opts: ObjectOptionPropsArgs<T>
+): ObjectOption<T> => {
+  return new ObjectOption<T>({
+    required: false,
     ...opts,
   });
 };
@@ -66,6 +78,7 @@ const option = {
   number,
   bool,
   array,
+  object,
   schema,
 };
 

--- a/src/option/array.ts
+++ b/src/option/array.ts
@@ -3,17 +3,18 @@ import { InvalidValue } from "@/types";
 
 import type { OptionTypes } from ".";
 import ArrayValueContainer from "./arrayOption";
-import type { Node, Value } from "./base";
+import type { Value } from "./base";
 import OptionBase from "./base";
 import OptionErrors from "./errors";
+import ObjectOption from "./object";
 
-interface ArrayOptionClassParams<T extends Node | OptionTypes> {
+interface ArrayOptionClassParams<T extends OptionTypes> {
   required: boolean;
   defaultValue?: SchemaValue<T>[] | (() => SchemaValue<T>[]);
   item: T;
 }
 export default class ArrayOption<
-  T extends Node | OptionTypes
+  T extends OptionTypes
 > extends OptionBase<"array"> {
   item: T;
 
@@ -48,7 +49,10 @@ export default class ArrayOption<
   ): Value {
     if (val instanceof ArrayValueContainer) {
       val.val.forEach((v, i) => {
-        if (this.item instanceof OptionBase) {
+        if (
+          this.item instanceof OptionBase &&
+          !(this.item instanceof ObjectOption)
+        ) {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           this.item.checkType(v, [...path, i], sourceOfVal);
         }

--- a/src/option/arrayOption.ts
+++ b/src/option/arrayOption.ts
@@ -1,13 +1,13 @@
 import type { ArrayValue } from "@/types";
 
-import type { Node, OptionTypes } from ".";
+import type { OptionTypes } from ".";
 
 class ArrayValueContainer {
   public readonly val: ArrayValue;
 
-  public readonly item: Node | OptionTypes;
+  public readonly item: OptionTypes;
 
-  constructor(item: Node | OptionTypes, val: ArrayValue) {
+  constructor(item: OptionTypes, val: ArrayValue) {
     this.val = val;
     this.item = item;
   }

--- a/src/option/base.ts
+++ b/src/option/base.ts
@@ -33,10 +33,9 @@ export type TypedDefaultValue<T extends OptionKind> = T extends PrimitiveKind
   ? TypeOfPrimitiveKind<T> | (() => TypeOfPrimitiveKind<T>)
   : DefaultValue;
 
-type RecursiveNode<T> = { [key: string]: OptionBase | T };
-
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface Node extends RecursiveNode<Node> {}
+export interface Node {
+  [key: string]: OptionBase;
+}
 
 interface OptionClassParams<T extends OptionKind> {
   kind: T;

--- a/src/option/index.ts
+++ b/src/option/index.ts
@@ -2,14 +2,19 @@ import ArrayOption from "./array";
 import ArrayValueContainer from "./arrayOption";
 import OptionBase, { type Node } from "./base";
 import OptionErrors from "./errors";
+import ObjectOption from "./object";
 import PrimitiveOption from "./primitive";
 
-export type OptionTypes = PrimitiveOption | ArrayOption<Node | OptionTypes>;
+export type OptionTypes =
+  | PrimitiveOption
+  | ArrayOption<OptionTypes>
+  | ObjectOption<Node>;
 
 export {
   ArrayOption,
   ArrayValueContainer,
   Node,
+  ObjectOption,
   OptionBase,
   OptionErrors,
   PrimitiveOption,

--- a/src/option/object.ts
+++ b/src/option/object.ts
@@ -1,0 +1,24 @@
+import type { Node } from "./base";
+import OptionBase from "./base";
+
+interface ObjectOptionClassParams<T extends Node> {
+  required: boolean;
+  item: T;
+}
+
+export default class ObjectOption<
+  T extends Node = Node
+> extends OptionBase<"object"> {
+  item: T;
+
+  constructor(params: ObjectOptionClassParams<T>) {
+    super({
+      kind: "object",
+      env: null,
+      cli: false,
+      help: "",
+      ...params,
+    });
+    this.item = params.item;
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,6 +8,7 @@ import ConfigNodeArray from "./nodes/configNodeArray";
 import type { Node, OptionTypes } from "./option";
 import {
   ArrayValueContainer,
+  ObjectOption,
   OptionBase,
   OptionErrors,
   PrimitiveOption,
@@ -152,9 +153,15 @@ class Settings<T extends Node> {
     path: Path,
     callback: (nodearg: OptionBase, patharg: Path) => void
   ): void {
-    if (node instanceof OptionBase) {
+    if (node instanceof ObjectOption) {
+      const item = node.item as Node;
+      Object.keys(item).forEach((key: string) => {
+        this.traverseOptions(item[key], [...path, key], callback);
+      });
+    } else if (node instanceof OptionBase) {
       callback(node, path);
     } else {
+      // Root-level Node only
       Object.keys(node).forEach((key: string) => {
         const val = node[key];
         this.traverseOptions(val, [...path, key], callback);
@@ -197,7 +204,7 @@ class Settings<T extends Node> {
   }
 
   private getValidatedArray(
-    item: Node | OptionTypes,
+    item: OptionTypes,
     values: ArrayValue,
     file: string
   ): ArrayValue | ConfigNodeArray {
@@ -228,7 +235,7 @@ class Settings<T extends Node> {
   }
 
   private processArrayWithSchema(
-    item: Node | OptionTypes,
+    item: OptionTypes,
     v: ConfigFileData,
     file: string
   ): NodeTree {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,11 @@
 import type ConfigNode from "./nodes/configNode";
-import type { ArrayOption, Node, OptionBase, OptionTypes } from "./option";
+import type {
+  ArrayOption,
+  Node,
+  ObjectOption,
+  OptionBase,
+  OptionTypes,
+} from "./option";
 import type PrimitiveOption from "./option/primitive";
 
 export type ProcessEnv = { [key: string]: string | undefined };
@@ -19,7 +25,7 @@ export type SettingsSources<T> = {
   exitOnError?: boolean;
 };
 
-export type OptionKind = "boolean" | "string" | "number" | "array";
+export type OptionKind = "boolean" | "string" | "number" | "array" | "object";
 
 export type PrimitiveKind = Extract<
   OptionKind,
@@ -35,8 +41,10 @@ export type TypeOfPrimitiveKind<T extends PrimitiveKind> = T extends "boolean"
   : never;
 
 export type SchemaValue<T extends OptionBase | Node> = T extends OptionBase
-  ? T extends ArrayOption<Node | OptionTypes>
+  ? T extends ArrayOption<OptionTypes>
     ? SchemaValue<T["item"]>[]
+    : T extends ObjectOption<infer R>
+    ? { [K in keyof R]: SchemaValue<R[K]> }
     : T extends PrimitiveOption<infer R>
     ? TypeOfPrimitiveKind<R>
     : never

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -34,18 +34,22 @@ describe("Settings", () => {
         .schema({
           string: option.string({ required: true }),
           number: option.number({ required: true }),
-          object: {
-            value: option.number({ required: true }),
-            name: option.string({ required: true }),
-          },
-          stringArray: option.array({ required: true, item: option.string() }),
-          numberArray: option.array({ required: true, item: option.number() }),
-          objectArray: option.array({
-            required: true,
+          object: option.object({
             item: {
               value: option.number({ required: true }),
               name: option.string({ required: true }),
             },
+          }),
+          stringArray: option.array({ required: true, item: option.string() }),
+          numberArray: option.array({ required: true, item: option.number() }),
+          objectArray: option.array({
+            required: true,
+            item: option.object({
+              item: {
+                value: option.number({ required: true }),
+                name: option.string({ required: true }),
+              },
+            }),
           }),
         })
         .load({
@@ -94,13 +98,17 @@ describe("Settings", () => {
       it("should return the object as it appears in the yaml file", () => {
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({ required: true, cli: true }),
-                minRam: option.number({ required: true, cli: true }),
-                openSource: option.bool({ required: true, cli: true }),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({ required: true, cli: true }),
+                    minRam: option.number({ required: true, cli: true }),
+                    openSource: option.bool({ required: true, cli: true }),
+                  },
+                }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -119,13 +127,17 @@ describe("Settings", () => {
         addCliArg("database.engine.name", "MySQL");
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({ required: true, cli: true }),
-                minRam: option.number({ required: true, cli: true }),
-                openSource: option.bool({ required: true, cli: true }),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({ required: true, cli: true }),
+                    minRam: option.number({ required: true, cli: true }),
+                    openSource: option.bool({ required: true, cli: true }),
+                  },
+                }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -142,13 +154,17 @@ describe("Settings", () => {
         addCliArg("database.engine.minRam", "32");
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({ required: true, cli: true }),
-                minRam: option.number({ required: true, cli: true }),
-                openSource: option.bool({ required: true, cli: true }),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({ required: true, cli: true }),
+                    minRam: option.number({ required: true, cli: true }),
+                    openSource: option.bool({ required: true, cli: true }),
+                  },
+                }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -165,13 +181,17 @@ describe("Settings", () => {
         addCliArg("database.engine.openSource", "false");
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({ required: true, cli: true }),
-                minRam: option.number({ required: true, cli: true }),
-                openSource: option.bool({ required: true, cli: true }),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({ required: true, cli: true }),
+                    minRam: option.number({ required: true, cli: true }),
+                    openSource: option.bool({ required: true, cli: true }),
+                  },
+                }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -190,13 +210,17 @@ describe("Settings", () => {
         addCliArg("unknown.veryUnknown.name", "MySQL");
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({}),
-                minRam: option.number({}),
-                openSource: option.bool({}),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({}),
+                    minRam: option.number({}),
+                    openSource: option.bool({}),
+                  },
+                }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -217,13 +241,17 @@ describe("Settings", () => {
         addCliArg("database.engine.openSource", "false");
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({ required: true, cli: true }),
-                minRam: option.number({ required: true, cli: true }),
-                openSource: option.bool({ required: true, cli: true }),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({ required: true, cli: true }),
+                    minRam: option.number({ required: true, cli: true }),
+                    openSource: option.bool({ required: true, cli: true }),
+                  },
+                }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -244,9 +272,11 @@ describe("Settings", () => {
       it("should return the string value if it exists and is valid", () => {
         const data = option
           .schema({
-            hardware: {
-              type: option.string({ required: true, env: "SITE_ID" }),
-            },
+            hardware: option.object({
+              item: {
+                type: option.string({ required: true, env: "SITE_ID" }),
+              },
+            }),
           })
           .load({
             env: false,
@@ -262,9 +292,11 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              hardware: {
-                type: option.string({ required: true, env: "SITE_ID" }),
-              },
+              hardware: option.object({
+                item: {
+                  type: option.string({ required: true, env: "SITE_ID" }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -285,10 +317,12 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              hardware: {
-                size: option.string({ required: true }),
-                brand: option.string({ required: true }),
-              },
+              hardware: option.object({
+                item: {
+                  size: option.string({ required: true }),
+                  brand: option.string({ required: true }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -314,12 +348,14 @@ describe("Settings", () => {
       it("should return the array if it exists and is valid", () => {
         const data = option
           .schema({
-            database: {
-              engines: option.array({
-                required: true,
-                item: option.string({ required: true }),
-              }),
-            },
+            database: option.object({
+              item: {
+                engines: option.array({
+                  required: true,
+                  item: option.string({ required: true }),
+                }),
+              },
+            }),
           })
           .load({
             env: false,
@@ -336,12 +372,14 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                engines: option.array({
-                  required: true,
-                  item: option.string({ required: true }),
-                }),
-              },
+              database: option.object({
+                item: {
+                  engines: option.array({
+                    required: true,
+                    item: option.string({ required: true }),
+                  }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -362,10 +400,12 @@ describe("Settings", () => {
       it("should return the number if it exists and is valid", () => {
         const data = option
           .schema({
-            database: {
-              ram: option.number({ required: true }),
-              cpus: option.number({ required: true }),
-            },
+            database: option.object({
+              item: {
+                ram: option.number({ required: true }),
+                cpus: option.number({ required: true }),
+              },
+            }),
           })
           .load({
             env: false,
@@ -381,9 +421,11 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                ram: option.number({ required: true }),
-              },
+              database: option.object({
+                item: {
+                  ram: option.number({ required: true }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -403,12 +445,14 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                ram1: option.number({ required: true }),
-                ram2: option.number({ required: true }),
-                ram3: option.number({ required: true }),
-                ram4: option.number({ required: true }),
-              },
+              database: option.object({
+                item: {
+                  ram1: option.number({ required: true }),
+                  ram2: option.number({ required: true }),
+                  ram3: option.number({ required: true }),
+                  ram4: option.number({ required: true }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -436,12 +480,14 @@ describe("Settings", () => {
       it("should return the array if it exists and is valid", () => {
         const data = option
           .schema({
-            database: {
-              sizeOptions: option.array({
-                required: true,
-                item: option.number({ required: true }),
-              }),
-            },
+            database: option.object({
+              item: {
+                sizeOptions: option.array({
+                  required: true,
+                  item: option.number({ required: true }),
+                }),
+              },
+            }),
           })
           .load({
             env: false,
@@ -458,12 +504,14 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                sizeOptions: option.array({
-                  required: true,
-                  item: option.number({ required: true }),
-                }),
-              },
+              database: option.object({
+                item: {
+                  sizeOptions: option.array({
+                    required: true,
+                    item: option.number({ required: true }),
+                  }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -483,12 +531,14 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                sizeOptions: option.array({
-                  required: true,
-                  item: option.number({ required: true }),
-                }),
-              },
+              database: option.object({
+                item: {
+                  sizeOptions: option.array({
+                    required: true,
+                    item: option.number({ required: true }),
+                  }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -511,12 +561,14 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                sizeOptions: option.array({
-                  required: true,
-                  item: option.number({ required: true }),
-                }),
-              },
+              database: option.object({
+                item: {
+                  sizeOptions: option.array({
+                    required: true,
+                    item: option.number({ required: true }),
+                  }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -538,18 +590,20 @@ describe("Settings", () => {
       it("should return the bool if it exists and is valid", () => {
         const data = option
           .schema({
-            database: {
-              bool1: option.bool({ required: true }),
-              bool2: option.bool({ required: true }),
-              bool3: option.bool({ required: true }),
-              bool4: option.bool({ required: true }),
-              bool5: option.bool({ required: true }),
-              bool6: option.bool({ required: true }),
-              bool7: option.bool({ required: true }),
-              bool8: option.bool({ required: true }),
-              bool9: option.bool({ required: true }),
-              bool10: option.bool({ required: true }),
-            },
+            database: option.object({
+              item: {
+                bool1: option.bool({ required: true }),
+                bool2: option.bool({ required: true }),
+                bool3: option.bool({ required: true }),
+                bool4: option.bool({ required: true }),
+                bool5: option.bool({ required: true }),
+                bool6: option.bool({ required: true }),
+                bool7: option.bool({ required: true }),
+                bool8: option.bool({ required: true }),
+                bool9: option.bool({ required: true }),
+                bool10: option.bool({ required: true }),
+              },
+            }),
           })
           .load({
             env: false,
@@ -576,9 +630,11 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                bool1: option.bool({ required: true }),
-              },
+              database: option.object({
+                item: {
+                  bool1: option.bool({ required: true }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -598,11 +654,13 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                bool1: option.bool({ required: true }),
-                bool2: option.bool({ required: true }),
-                bool3: option.bool({ required: true }),
-              },
+              database: option.object({
+                item: {
+                  bool1: option.bool({ required: true }),
+                  bool2: option.bool({ required: true }),
+                  bool3: option.bool({ required: true }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -628,12 +686,14 @@ describe("Settings", () => {
       it("should return the array if it exists and is valid", () => {
         const data = option
           .schema({
-            database: {
-              bools: option.array({
-                required: true,
-                item: option.bool({ required: true }),
-              }),
-            },
+            database: option.object({
+              item: {
+                bools: option.array({
+                  required: true,
+                  item: option.bool({ required: true }),
+                }),
+              },
+            }),
           })
           .load({
             env: false,
@@ -669,12 +729,14 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                bools: option.array({
-                  required: true,
-                  item: option.bool({ required: true }),
-                }),
-              },
+              database: option.object({
+                item: {
+                  bools: option.array({
+                    required: true,
+                    item: option.bool({ required: true }),
+                  }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -694,12 +756,14 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                bools: option.array({
-                  required: true,
-                  item: option.bool({ required: true }),
-                }),
-              },
+              database: option.object({
+                item: {
+                  bools: option.array({
+                    required: true,
+                    item: option.bool({ required: true }),
+                  }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -725,16 +789,20 @@ describe("Settings", () => {
       it("should return the array if it exists and is valid", () => {
         const data = option
           .schema({
-            database: {
-              engines: option.array({
-                required: true,
-                item: {
-                  name: option.string({ required: true }),
-                  minRam: option.number({ required: true }),
-                  openSource: option.bool({ required: true }),
-                },
-              }),
-            },
+            database: option.object({
+              item: {
+                engines: option.array({
+                  required: true,
+                  item: option.object({
+                    item: {
+                      name: option.string({ required: true }),
+                      minRam: option.number({ required: true }),
+                      openSource: option.bool({ required: true }),
+                    },
+                  }),
+                }),
+              },
+            }),
           })
           .load({
             env: false,
@@ -757,16 +825,20 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                engines: option.array({
-                  required: true,
-                  item: {
-                    name: option.string({ required: true }),
-                    minRam: option.number({ required: true }),
-                    openSource: option.bool({ required: true }),
-                  },
-                }),
-              },
+              database: option.object({
+                item: {
+                  engines: option.array({
+                    required: true,
+                    item: option.object({
+                      item: {
+                        name: option.string({ required: true }),
+                        minRam: option.number({ required: true }),
+                        openSource: option.bool({ required: true }),
+                      },
+                    }),
+                  }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -786,16 +858,20 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                engines: option.array({
-                  required: true,
-                  item: {
-                    name: option.string({ required: true }),
-                    minRam: option.number({ required: true }),
-                    openSource: option.bool({ required: true }),
-                  },
-                }),
-              },
+              database: option.object({
+                item: {
+                  engines: option.array({
+                    required: true,
+                    item: option.object({
+                      item: {
+                        name: option.string({ required: true }),
+                        minRam: option.number({ required: true }),
+                        openSource: option.bool({ required: true }),
+                      },
+                    }),
+                  }),
+                },
+              }),
             })
             .load({
               env: false,
@@ -815,13 +891,17 @@ describe("Settings", () => {
       it("should return the object if it exists and is valid", () => {
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({ required: true }),
-                minRam: option.number({ required: true }),
-                openSource: option.bool({ required: true }),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({ required: true }),
+                    minRam: option.number({ required: true }),
+                    openSource: option.bool({ required: true }),
+                  },
+                }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -839,13 +919,17 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                engine: {
-                  name: option.string({ required: true }),
-                  minRam: option.number({ required: true }),
-                  openSource: option.bool({ required: true }),
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      name: option.string({ required: true }),
+                      minRam: option.number({ required: true }),
+                      openSource: option.bool({ required: true }),
+                    },
+                  }),
                 },
-              },
+              }),
             })
             .load({
               env: false,
@@ -864,25 +948,35 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                engine: {
-                  name: option.string({ required: true }),
-                  minRam: option.number({ required: true }),
-                  openSource: option.bool({ required: true }),
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      name: option.string({ required: true }),
+                      minRam: option.number({ required: true }),
+                      openSource: option.bool({ required: true }),
+                    },
+                  }),
+                  cpu: option.object({
+                    item: {
+                      brand: option.string({ required: true }),
+                      cores: option.number({ required: true }),
+                      power: option.bool({ required: true }),
+                    },
+                  }),
+                  openSource: option.object({
+                    item: {
+                      url: option.string({ required: true }),
+                    },
+                  }),
+                  date: option.object({
+                    item: {
+                      start: option.string({ required: true }),
+                      end: option.string({ required: true }),
+                    },
+                  }),
                 },
-                cpu: {
-                  brand: option.string({ required: true }),
-                  cores: option.number({ required: true }),
-                  power: option.bool({ required: true }),
-                },
-                openSource: {
-                  url: option.string({ required: true }),
-                },
-                date: {
-                  start: option.string({ required: true }),
-                  end: option.string({ required: true }),
-                },
-              },
+              }),
             })
             .load({
               env: false,
@@ -915,22 +1009,26 @@ describe("Settings", () => {
                 cli: false,
                 defaultValue: "MySQL",
               }),
-              database: {
-                engine: {
-                  name: option.string({
-                    cli: false,
-                    defaultValue: "MySQL",
-                  }),
-                  minRam: option.number({
-                    cli: false,
-                    defaultValue: 64,
-                  }),
-                  openSource: option.bool({
-                    cli: false,
-                    defaultValue: false,
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      name: option.string({
+                        cli: false,
+                        defaultValue: "MySQL",
+                      }),
+                      minRam: option.number({
+                        cli: false,
+                        defaultValue: 64,
+                      }),
+                      openSource: option.bool({
+                        cli: false,
+                        defaultValue: false,
+                      }),
+                    },
                   }),
                 },
-              },
+              }),
             })
             .load({
               env: false,
@@ -957,22 +1055,26 @@ describe("Settings", () => {
                 cli: false,
                 defaultValue: () => "MySQL",
               }),
-              database: {
-                engine: {
-                  name: option.string({
-                    cli: false,
-                    defaultValue: () => "MySQL",
-                  }),
-                  minRam: option.number({
-                    cli: false,
-                    defaultValue: () => 64,
-                  }),
-                  openSource: option.bool({
-                    cli: false,
-                    defaultValue: () => false,
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      name: option.string({
+                        cli: false,
+                        defaultValue: () => "MySQL",
+                      }),
+                      minRam: option.number({
+                        cli: false,
+                        defaultValue: () => 64,
+                      }),
+                      openSource: option.bool({
+                        cli: false,
+                        defaultValue: () => false,
+                      }),
+                    },
                   }),
                 },
-              },
+              }),
             })
             .load({
               env: false,
@@ -998,15 +1100,19 @@ describe("Settings", () => {
         it("should return the default array", () => {
           const data = option
             .schema({
-              database: {
-                engine: {
-                  versions: option.array({
-                    required: true,
-                    item: option.string({ required: true }),
-                    defaultValue: ["1.0.0", "1.1.0", "1.2.0"],
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      versions: option.array({
+                        required: true,
+                        item: option.string({ required: true }),
+                        defaultValue: ["1.0.0", "1.1.0", "1.2.0"],
+                      }),
+                    },
                   }),
                 },
-              },
+              }),
             })
             .load({
               env: false,
@@ -1026,15 +1132,19 @@ describe("Settings", () => {
         it("should return the default array", () => {
           const data = option
             .schema({
-              database: {
-                engine: {
-                  versions: option.array({
-                    required: true,
-                    item: option.string({ required: true }),
-                    defaultValue: () => ["1.0.0", "1.1.0", "1.2.0"],
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      versions: option.array({
+                        required: true,
+                        item: option.string({ required: true }),
+                        defaultValue: () => ["1.0.0", "1.1.0", "1.2.0"],
+                      }),
+                    },
                   }),
                 },
-              },
+              }),
             })
             .load({
               env: false,
@@ -1056,22 +1166,26 @@ describe("Settings", () => {
       it("should override the default value", () => {
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({
-                  cli: false,
-                  defaultValue: "MySQL",
-                }),
-                minRam: option.number({
-                  cli: false,
-                  defaultValue: 64,
-                }),
-                openSource: option.bool({
-                  cli: false,
-                  defaultValue: false,
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({
+                      cli: false,
+                      defaultValue: "MySQL",
+                    }),
+                    minRam: option.number({
+                      cli: false,
+                      defaultValue: 64,
+                    }),
+                    openSource: option.bool({
+                      cli: false,
+                      defaultValue: false,
+                    }),
+                  },
                 }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -1094,15 +1208,19 @@ describe("Settings", () => {
       it("should override the default value", () => {
         const data = option
           .schema({
-            database: {
-              engine: {
-                versions: option.array({
-                  required: true,
-                  item: option.string({ required: true }),
-                  defaultValue: ["1.0.0", "1.1.0", "1.2.0"],
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    versions: option.array({
+                      required: true,
+                      item: option.string({ required: true }),
+                      defaultValue: ["1.0.0", "1.1.0", "1.2.0"],
+                    }),
+                  },
                 }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -1125,14 +1243,18 @@ describe("Settings", () => {
       it("should return the default value", () => {
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({}),
-                minRam: option.number({}),
-                openSource: option.bool({}),
-                versions: option.array({ item: option.string() }),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({}),
+                    minRam: option.number({}),
+                    openSource: option.bool({}),
+                    versions: option.array({ item: option.string() }),
+                  },
+                }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -1166,15 +1288,19 @@ describe("Settings", () => {
       it("should override the default value", () => {
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({}),
-                minRam: option.number({}),
-                openSource: option.bool({}),
-                cpus: option.number({}),
-                versions: option.array({ item: option.string() }),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({}),
+                    minRam: option.number({}),
+                    openSource: option.bool({}),
+                    cpus: option.number({}),
+                    versions: option.array({ item: option.string() }),
+                  },
+                }),
               },
-            },
+            }),
           })
           .load({
             env: false,
@@ -1212,19 +1338,25 @@ describe("Settings", () => {
       it("should set all values", () => {
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({ required: true, cli: true }),
-                minRam: option.number({ required: true, cli: true }),
-                openSource: option.bool({ required: true, cli: true }),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({ required: true, cli: true }),
+                    minRam: option.number({ required: true, cli: true }),
+                    openSource: option.bool({ required: true, cli: true }),
+                  },
+                }),
               },
-            },
+            }),
             features: option.array({
               required: true,
-              item: {
-                name: option.string({ required: true }),
-                enabled: option.bool({ required: true }),
-              },
+              item: option.object({
+                item: {
+                  name: option.string({ required: true }),
+                  enabled: option.bool({ required: true }),
+                },
+              }),
             }),
             version: option.string({ required: true }),
             upgraded: option.bool({ required: true }),
@@ -1258,12 +1390,16 @@ describe("Settings", () => {
       it("should prioritize first loaded file", () => {
         const data = option
           .schema({
-            file1Data: {
-              unique: option.bool({ required: true }),
-            },
-            file2Data: {
-              unique: option.bool({ required: true }),
-            },
+            file1Data: option.object({
+              item: {
+                unique: option.bool({ required: true }),
+              },
+            }),
+            file2Data: option.object({
+              item: {
+                unique: option.bool({ required: true }),
+              },
+            }),
             version: option.string({ required: true }),
             upgraded: option.bool({ required: true }),
             cpus: option.number({ required: true }),
@@ -1292,13 +1428,15 @@ describe("Settings", () => {
       it("should prioritize first loaded file", () => {
         const data = option
           .schema({
-            database: {
-              name: option.string({ required: true }),
-              minRam: option.number({ required: true }),
-              openSource: option.bool({ required: true }),
-              maxRam: option.number({ required: true }),
-              version: option.string({ required: true }),
-            },
+            database: option.object({
+              item: {
+                name: option.string({ required: true }),
+                minRam: option.number({ required: true }),
+                openSource: option.bool({ required: true }),
+                maxRam: option.number({ required: true }),
+                version: option.string({ required: true }),
+              },
+            }),
           })
           .load({
             env: false,
@@ -1345,15 +1483,19 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                engine: {
-                  name: option.string({ required: true }),
-                  minRam: option.number({ required: true }),
-                  openSource: option.bool({ required: true }),
-                  // control test, this value should appear on the files
-                  launchDate: option.string({ required: true }),
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      name: option.string({ required: true }),
+                      minRam: option.number({ required: true }),
+                      openSource: option.bool({ required: true }),
+                      // control test, this value should appear on the files
+                      launchDate: option.string({ required: true }),
+                    },
+                  }),
                 },
-              },
+              }),
             })
             .load({
               env: false,
@@ -1383,13 +1525,17 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                engine: {
-                  name: option.string({ required: true, cli: true }),
-                  minRam: option.number({ required: true, cli: true }),
-                  openSource: option.bool({ required: true, cli: true }),
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      name: option.string({ required: true, cli: true }),
+                      minRam: option.number({ required: true, cli: true }),
+                      openSource: option.bool({ required: true, cli: true }),
+                    },
+                  }),
                 },
-              },
+              }),
             })
             .load({
               env: false,
@@ -1410,13 +1556,17 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                engine: {
-                  name: option.string({ required: true, cli: true }),
-                  minRam: option.number({ required: true, cli: true }),
-                  openSource: option.bool({ required: true, cli: true }),
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      name: option.string({ required: true, cli: true }),
+                      minRam: option.number({ required: true, cli: true }),
+                      openSource: option.bool({ required: true, cli: true }),
+                    },
+                  }),
                 },
-              },
+              }),
             })
             .load({
               env: false,
@@ -1438,19 +1588,25 @@ describe("Settings", () => {
       it("should set all values", () => {
         const data = option
           .schema({
-            database: {
-              engine: {
-                name: option.string({ required: true, cli: true }),
-                minRam: option.number({ required: true, cli: true }),
-                openSource: option.bool({ required: true, cli: true }),
+            database: option.object({
+              item: {
+                engine: option.object({
+                  item: {
+                    name: option.string({ required: true, cli: true }),
+                    minRam: option.number({ required: true, cli: true }),
+                    openSource: option.bool({ required: true, cli: true }),
+                  },
+                }),
               },
-            },
+            }),
             features: option.array({
               required: true,
-              item: {
-                name: option.string({ required: true }),
-                enabled: option.bool({ required: true }),
-              },
+              item: option.object({
+                item: {
+                  name: option.string({ required: true }),
+                  enabled: option.bool({ required: true }),
+                },
+              }),
             }),
             version: option.string({ required: true }),
             upgraded: option.bool({ required: true }),
@@ -1480,12 +1636,16 @@ describe("Settings", () => {
       it("should prioritize first loaded file", () => {
         const data = option
           .schema({
-            file1Data: {
-              unique: option.bool({ required: true }),
-            },
-            file2Data: {
-              unique: option.bool({ required: true }),
-            },
+            file1Data: option.object({
+              item: {
+                unique: option.bool({ required: true }),
+              },
+            }),
+            file2Data: option.object({
+              item: {
+                unique: option.bool({ required: true }),
+              },
+            }),
             version: option.string({ required: true }),
             upgraded: option.bool({ required: true }),
             cpus: option.number({ required: true }),
@@ -1511,13 +1671,15 @@ describe("Settings", () => {
       it("should prioritize first loaded file", () => {
         const data = option
           .schema({
-            database: {
-              name: option.string({ required: true }),
-              minRam: option.number({ required: true }),
-              openSource: option.bool({ required: true }),
-              maxRam: option.number({ required: true }),
-              version: option.string({ required: true }),
-            },
+            database: option.object({
+              item: {
+                name: option.string({ required: true }),
+                minRam: option.number({ required: true }),
+                openSource: option.bool({ required: true }),
+                maxRam: option.number({ required: true }),
+                version: option.string({ required: true }),
+              },
+            }),
           })
           .load({
             env: false,
@@ -1558,15 +1720,19 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                engine: {
-                  name: option.string({ required: true }),
-                  minRam: option.number({ required: true }),
-                  openSource: option.bool({ required: true }),
-                  // control test, this value should appear on the files
-                  launchDate: option.string({ required: true }),
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      name: option.string({ required: true }),
+                      minRam: option.number({ required: true }),
+                      openSource: option.bool({ required: true }),
+                      // control test, this value should appear on the files
+                      launchDate: option.string({ required: true }),
+                    },
+                  }),
                 },
-              },
+              }),
             })
             .load({
               env: false,
@@ -1592,13 +1758,17 @@ describe("Settings", () => {
         expect(() =>
           option
             .schema({
-              database: {
-                engine: {
-                  name: option.string({ required: true, cli: true }),
-                  minRam: option.number({ required: true, cli: true }),
-                  openSource: option.bool({ required: true, cli: true }),
+              database: option.object({
+                item: {
+                  engine: option.object({
+                    item: {
+                      name: option.string({ required: true, cli: true }),
+                      minRam: option.number({ required: true, cli: true }),
+                      openSource: option.bool({ required: true, cli: true }),
+                    },
+                  }),
                 },
-              },
+              }),
             })
             .load({
               env: false,
@@ -1619,10 +1789,12 @@ describe("Settings", () => {
           .schema({
             string: option.string({ required: true }),
             number: option.number({ required: true }),
-            object: {
-              value: option.number({ required: true }),
-              name: option.string({ required: true }),
-            },
+            object: option.object({
+              item: {
+                value: option.number({ required: true }),
+                name: option.string({ required: true }),
+              },
+            }),
             stringArray: option.array({
               required: true,
               item: option.string(),
@@ -1633,10 +1805,12 @@ describe("Settings", () => {
             }),
             objectArray: option.array({
               required: true,
-              item: {
-                value: option.number({ required: true }),
-                name: option.string({ required: true }),
-              },
+              item: option.object({
+                item: {
+                  value: option.number({ required: true }),
+                  name: option.string({ required: true }),
+                },
+              }),
             }),
           })
           .load({
@@ -1655,10 +1829,12 @@ describe("Settings", () => {
           .schema({
             string: option.string({ required: true }),
             number: option.number({ required: true }),
-            object: {
-              value: option.number({ required: true }),
-              name: option.string({ required: true }),
-            },
+            object: option.object({
+              item: {
+                value: option.number({ required: true }),
+                name: option.string({ required: true }),
+              },
+            }),
             stringArray: option.array({
               required: true,
               item: option.string(),
@@ -1669,10 +1845,12 @@ describe("Settings", () => {
             }),
             objectArray: option.array({
               required: true,
-              item: {
-                value: option.number({ required: true }),
-                name: option.string({ required: true }),
-              },
+              item: option.object({
+                item: {
+                  value: option.number({ required: true }),
+                  name: option.string({ required: true }),
+                },
+              }),
             }),
           })
           .load({
@@ -1691,10 +1869,12 @@ describe("Settings", () => {
           .schema({
             string: option.string({ required: true }),
             number: option.number({ required: true }),
-            object: {
-              value: option.number({ required: true }),
-              name: option.string({ required: true }),
-            },
+            object: option.object({
+              item: {
+                value: option.number({ required: true }),
+                name: option.string({ required: true }),
+              },
+            }),
             stringArray: option.array({
               required: true,
               item: option.string(),
@@ -1705,10 +1885,12 @@ describe("Settings", () => {
             }),
             objectArray: option.array({
               required: true,
-              item: {
-                value: option.number({ required: true }),
-                name: option.string({ required: true }),
-              },
+              item: option.object({
+                item: {
+                  value: option.number({ required: true }),
+                  name: option.string({ required: true }),
+                },
+              }),
             }),
           })
           .load({
@@ -1755,11 +1937,13 @@ describe("Settings", () => {
       it("should return nested object values", () => {
         const data = option
           .schema({
-            test: {
-              boolean: option.bool({ required: true }),
-              number: option.number({ required: true }),
-              string: option.string({ required: true }),
-            },
+            test: option.object({
+              item: {
+                boolean: option.bool({ required: true }),
+                number: option.number({ required: true }),
+                string: option.string({ required: true }),
+              },
+            }),
           })
           .load({
             env: false,
@@ -1805,10 +1989,12 @@ describe("Settings", () => {
         .schema({
           string: option.string({ required: true }),
           number: option.number({ required: true }),
-          object: {
-            value: option.number({ required: true }),
-            name: option.string({ required: true }),
-          },
+          object: option.object({
+            item: {
+              value: option.number({ required: true }),
+              name: option.string({ required: true }),
+            },
+          }),
         })
         .loadExtended({
           env: false,

--- a/tests/type-tests/default-value-types.test-d.ts
+++ b/tests/type-tests/default-value-types.test-d.ts
@@ -49,3 +49,38 @@ c.array({ item: c.string(), defaultValue: [1, 2] });
 
 // @ts-expect-error — string[] is not assignable to number[] defaultValue
 c.array({ item: c.number(), defaultValue: ["a", "b"] });
+
+// --- ObjectOption type inference ---
+
+// Valid: object with nested primitives infers correctly
+c.object({ item: { name: c.string(), count: c.number() } });
+
+// Valid: object used as array item
+c.array({
+  item: c.object({ item: { name: c.string(), enabled: c.bool() } }),
+});
+
+// Valid: nested objects
+c.object({
+  item: {
+    child: c.object({ item: { value: c.number() } }),
+  },
+});
+
+// Valid: SchemaValue inference through schema
+const result = c
+  .schema({
+    config: c.object({
+      item: {
+        host: c.string({ required: true }),
+        port: c.number({ required: true }),
+      },
+    }),
+  })
+  .load({ env: false, args: false, files: false });
+
+// These lines verify that SchemaValue infers the correct nested types
+const host: string = result.config.host;
+const port: number = result.config.port;
+void host;
+void port;


### PR DESCRIPTION
## Summary

- **Add `option.object()`** — a new factory for declaring nested object schemas with metadata (`required`), matching the existing `ArrayOption` pattern. All nesting must now use `c.object({ item: ... })` instead of plain objects (plain objects remain valid only at the root schema level).
- **Remove dead `"any"` and `"object"` option kinds** — cleans up unused `OptionKind` variants and their associated code paths.

## Breaking Changes

- Nested object schemas must use `c.object({ item: { ... } })` instead of plain `{ ... }` objects.
- Removed `"any"` and `"object"` from `OptionKind` (these were dead code, but any external references will break).

## Test plan

- [x] `yarn type-check` passes with no errors
- [x] `yarn test` — all 83 tests pass
- [x] `yarn lint` — no warnings or errors
- [x] Compile-time type tests verify `ObjectOption` inference