### PR TITLE
feat: add Standard Schema validation support

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -64,6 +64,7 @@ No separate interface to maintain. No `as` casts. The types flow from the schema
 - **`.env` file support** — load environment variables from `.env` files with automatic line tracking
 - **Nested objects and arrays** — deeply nested configs with full type safety
 - **Structured errors** — typed `ConfigLoadError` with per-field error details and warnings
+- **Schema validation** — optional per-field validation via [Standard Schema](https://github.com/standard-schema/standard-schema) (Zod, Valibot, ArkType, or custom)
 - **Strict mode** — promote warnings to errors for production safety
 - **Default values** — static or computed (via functions)
 - **Multiple files / directory loading** — load from a list of files or an entire directory
@@ -253,6 +254,74 @@ c.array({
     item: { name: c.string(), age: c.number() },
   }),
 }); // { name: string; age: number }[]
+```
+
+## Validation
+
+Add per-field validation using the `validate` option. config-loader accepts any [Standard Schema v1](https://github.com/standard-schema/standard-schema) implementation — including **Zod**, **Valibot**, and **ArkType** — or a custom validator.
+
+Validation runs **after** type coercion, so validators see the final typed value (e.g., the number `3000`, not the string `"3000"` from an env var).
+
+### With Zod
+
+```typescript
+import c from "@meltstudio/config-loader";
+import { z } from "zod";
+
+const config = c
+  .schema({
+    port: c.number({
+      required: true,
+      env: "PORT",
+      validate: z.number().min(1).max(65535),
+    }),
+    host: c.string({
+      required: true,
+      validate: z.string().url(),
+    }),
+    env: c.string({
+      defaultValue: "development",
+      validate: z.enum(["development", "staging", "production"]),
+    }),
+  })
+  .load({ env: true, args: false, files: "./config.yaml" });
+```
+
+### With a custom validator
+
+Any object with a `~standard.validate()` method works:
+
+```typescript
+const portValidator = {
+  "~standard": {
+    version: 1,
+    vendor: "my-app",
+    validate(value: unknown) {
+      if (typeof value === "number" && value >= 1 && value <= 65535) {
+        return { value };
+      }
+      return { issues: [{ message: "must be a valid port (1-65535)" }] };
+    },
+  },
+};
+
+c.number({ required: true, env: "PORT", validate: portValidator });
+```
+
+Validation errors are collected alongside other config errors and thrown as `ConfigLoadError` with `kind: "validation"`:
+
+```typescript
+try {
+  const config = c.schema({ ... }).load({ ... });
+} catch (err) {
+  if (err instanceof ConfigLoadError) {
+    for (const entry of err.errors) {
+      if (entry.kind === "validation") {
+        console.error(`Validation: ${entry.path} — ${entry.message}`);
+      }
+    }
+  }
+}
 ```
 
 ## Loading Sources

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -151,6 +151,7 @@ export default tseslint.config(
       "max-lines": "off",
       // Jest matchers (expect.stringContaining, etc.) return `any`
       "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/explicit-function-return-type": "off",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -16,7 +16,8 @@ export interface ConfigErrorEntry {
     | "invalid_state"
     | "file_validation"
     | "null_value"
-    | "strict";
+    | "strict"
+    | "validation";
   /** Line number in the config file where the error occurred, if applicable. */
   line?: number;
   /** Column number in the config file where the error occurred, if applicable. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,11 @@ import { SettingsBuilder } from "@/builder";
 
 import type { Node, OptionTypes } from "./option";
 import { ArrayOption, ObjectOption, PrimitiveOption } from "./option";
-import type { SchemaValue } from "./types";
+import type { SchemaValue, StandardSchemaV1 } from "./types";
 
 export type { ConfigErrorEntry } from "./errors";
 export { ConfigFileError, ConfigLoadError } from "./errors";
-export type { ExtendedResult } from "./types";
+export type { ExtendedResult, StandardSchemaV1 } from "./types";
 
 /** Options for configuring a primitive (`string`, `number`, `bool`) schema field. */
 interface OptionPropsArgs<T> {
@@ -20,6 +20,8 @@ interface OptionPropsArgs<T> {
   defaultValue?: T | (() => T);
   /** Help text shown in CLI `--help` output. */
   help?: string;
+  /** Standard Schema validator run after type coercion. Accepts Zod, Valibot, ArkType, or any Standard Schema v1 implementation. */
+  validate?: StandardSchemaV1;
 }
 /** Options for configuring an `array` schema field. */
 interface ArrayOptionPropsArgs<T extends OptionTypes> {
@@ -29,6 +31,8 @@ interface ArrayOptionPropsArgs<T extends OptionTypes> {
   item: T;
   /** Static default value or factory function returning one. */
   defaultValue?: SchemaValue<T>[] | (() => SchemaValue<T>[]);
+  /** Standard Schema validator run on the resolved array. Accepts Zod, Valibot, ArkType, or any Standard Schema v1 implementation. */
+  validate?: StandardSchemaV1;
 }
 /** Options for configuring a nested `object` schema field. */
 interface ObjectOptionPropsArgs<T extends Node> {
@@ -36,6 +40,8 @@ interface ObjectOptionPropsArgs<T extends Node> {
   required?: boolean;
   /** Schema definition for the nested object's shape. */
   item: T;
+  /** Standard Schema validator run on the resolved object. Accepts Zod, Valibot, ArkType, or any Standard Schema v1 implementation. */
+  validate?: StandardSchemaV1;
 }
 
 const DEFAULTS = {

--- a/src/option/array.ts
+++ b/src/option/array.ts
@@ -1,4 +1,9 @@
-import type { ConfigFileData, Path, SchemaValue } from "@/types";
+import type {
+  ConfigFileData,
+  Path,
+  SchemaValue,
+  StandardSchemaV1,
+} from "@/types";
 import { InvalidValue } from "@/types";
 
 import type { OptionTypes } from ".";
@@ -12,6 +17,7 @@ interface ArrayOptionClassParams<T extends OptionTypes> {
   required: boolean;
   defaultValue?: SchemaValue<T>[] | (() => SchemaValue<T>[]);
   item: T;
+  validate?: StandardSchemaV1;
 }
 export default class ArrayOption<
   T extends OptionTypes,

--- a/src/option/object.ts
+++ b/src/option/object.ts
@@ -1,9 +1,12 @@
+import type { StandardSchemaV1 } from "@/types";
+
 import type { Node } from "./base";
 import OptionBase from "./base";
 
 interface ObjectOptionClassParams<T extends Node> {
   required: boolean;
   item: T;
+  validate?: StandardSchemaV1;
 }
 
 export default class ObjectOption<

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,3 +84,27 @@ export interface ConfigFileData extends ConfigFileStructure<ConfigFileData> {}
 export type ArrayValue = Array<string | number | boolean | ConfigFileData>;
 
 export class InvalidValue {}
+
+/**
+ * A single issue returned by a Standard Schema validator.
+ * Mirrors the Standard Schema v1 spec (https://github.com/standard-schema/standard-schema).
+ */
+export interface StandardSchemaIssue {
+  message: string;
+  path?: ReadonlyArray<PropertyKey>;
+}
+
+/**
+ * Minimal Standard Schema v1 interface for value validation.
+ * Any object with a `~standard.validate()` method is accepted — this covers
+ * Zod 3.24+, Valibot 1.0+, ArkType 2.1+, and custom validators.
+ */
+export interface StandardSchemaV1<Output = unknown> {
+  "~standard": {
+    version: 1;
+    vendor: string;
+    validate(
+      value: unknown,
+    ): { value: Output } | { issues: ReadonlyArray<StandardSchemaIssue> };
+  };
+}

--- a/tests/option.spec.ts
+++ b/tests/option.spec.ts
@@ -604,5 +604,21 @@ describe("option", () => {
       expect(errors.errors).toHaveLength(1);
       expect(errors.errors[0].kind).toBe("invalid_path");
     });
+
+    it("should push an invalid_path error for unsupported value types", () => {
+      const opt = new TestableOption({
+        kind: "string",
+        required: false,
+        env: null,
+        cli: false,
+        help: "",
+      });
+      // Force a bigint value to hit the fallthrough branch
+      const obj = { key: BigInt(42) } as any;
+      const result = opt.exposedFindInObject(obj, ["key"], errors);
+      expect(result).toBeInstanceOf(InvalidValue);
+      expect(errors.errors).toHaveLength(1);
+      expect(errors.errors[0].kind).toBe("invalid_path");
+    });
   });
 });

--- a/tests/validation.spec.ts
+++ b/tests/validation.spec.ts
@@ -1,0 +1,341 @@
+import { ConfigLoadError } from "@/errors";
+import optionFn from "@/src";
+import type { StandardSchemaV1 } from "@/types";
+
+/**
+ * Helper: creates a Standard Schema v1 validator from a predicate function.
+ */
+function createValidator<T>(
+  predicate: (value: unknown) => boolean,
+  message: string,
+): StandardSchemaV1<T> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate(value: unknown) {
+        if (predicate(value)) {
+          return { value: value as T };
+        }
+        return { issues: [{ message }] };
+      },
+    },
+  };
+}
+
+const FILE = "./tests/__mocks__/fileMock.yaml";
+
+function getLoadError(fn: () => unknown): ConfigLoadError {
+  try {
+    fn();
+  } catch (err) {
+    if (err instanceof ConfigLoadError) return err;
+    throw err;
+  }
+  throw new Error("Expected ConfigLoadError to be thrown");
+}
+
+describe("Standard Schema validation", () => {
+  describe("primitive options", () => {
+    it("should pass when validation succeeds", () => {
+      const config = optionFn
+        .schema({
+          number: optionFn.number({
+            defaultValue: 3000,
+            validate: createValidator<number>(
+              (v) => typeof v === "number" && v >= 1 && v <= 65535,
+              "must be between 1 and 65535",
+            ),
+          }),
+        })
+        .load({ env: false, args: false });
+
+      expect(config.number).toBe(3000);
+    });
+
+    it("should throw ConfigLoadError with kind 'validation' when validation fails", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            number: optionFn.number({
+              defaultValue: 99999,
+              validate: createValidator<number>(
+                (v) => typeof v === "number" && v >= 1 && v <= 65535,
+                "must be between 1 and 65535",
+              ),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0]).toMatchObject({
+        kind: "validation",
+        path: "number",
+        message: expect.stringContaining("must be between 1 and 65535"),
+      });
+    });
+
+    it("should validate after type coercion (env string → number)", () => {
+      const originalEnv = process.env;
+      process.env = { ...originalEnv, TEST_PORT: "8080" };
+      try {
+        const config = optionFn
+          .schema({
+            port: optionFn.number({
+              env: "TEST_PORT",
+              validate: createValidator<number>(
+                (v) => typeof v === "number" && v >= 1 && v <= 65535,
+                "must be a valid port",
+              ),
+            }),
+          })
+          .load({ env: true, args: false });
+
+        expect(config.port).toBe(8080);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    it("should fail validation on coerced env value", () => {
+      const originalEnv = process.env;
+      process.env = { ...originalEnv, TEST_PORT: "0" };
+      try {
+        const err = getLoadError(() =>
+          optionFn
+            .schema({
+              port: optionFn.number({
+                env: "TEST_PORT",
+                validate: createValidator<number>(
+                  (v) => typeof v === "number" && v >= 1,
+                  "must be positive",
+                ),
+              }),
+            })
+            .load({ env: true, args: false }),
+        );
+
+        expect(err.errors).toHaveLength(1);
+        expect(err.errors[0].kind).toBe("validation");
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    it("should validate string options", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            host: optionFn.string({
+              defaultValue: "not-a-url",
+              validate: createValidator<string>(
+                (v) => typeof v === "string" && v.startsWith("https://"),
+                "must start with https://",
+              ),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0]).toMatchObject({
+        kind: "validation",
+        message: expect.stringContaining("must start with https://"),
+      });
+    });
+
+    it("should validate boolean options", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            flag: optionFn.bool({
+              defaultValue: false,
+              validate: createValidator<boolean>(
+                (v) => v === true,
+                "must be true",
+              ),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0].kind).toBe("validation");
+    });
+
+    it("should collect multiple validation errors from multiple fields", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            port: optionFn.number({
+              defaultValue: -1,
+              validate: createValidator<number>(
+                (v) => typeof v === "number" && v > 0,
+                "must be positive",
+              ),
+            }),
+            host: optionFn.string({
+              defaultValue: "",
+              validate: createValidator<string>(
+                (v) => typeof v === "string" && v.length > 0,
+                "must not be empty",
+              ),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(2);
+      expect(err.errors[0].kind).toBe("validation");
+      expect(err.errors[1].kind).toBe("validation");
+    });
+
+    it("should collect multiple issues from a single validator", () => {
+      const multiIssueValidator: StandardSchemaV1<number> = {
+        "~standard": {
+          version: 1,
+          vendor: "test",
+          validate() {
+            return {
+              issues: [{ message: "too small" }, { message: "not even" }],
+            };
+          },
+        },
+      };
+
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            value: optionFn.number({
+              defaultValue: 3,
+              validate: multiIssueValidator,
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(2);
+      expect(err.errors[0].message).toContain("too small");
+      expect(err.errors[1].message).toContain("not even");
+    });
+  });
+
+  describe("with file sources", () => {
+    it("should validate values loaded from a YAML file", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            number: optionFn.number({
+              validate: createValidator<number>(
+                (v) => typeof v === "number" && v > 9999,
+                "must be greater than 9999",
+              ),
+            }),
+          })
+          .load({ env: false, args: false, files: FILE }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0]).toMatchObject({
+        kind: "validation",
+        path: "number",
+        source: FILE,
+      });
+    });
+
+    it("should pass validation for valid file values", () => {
+      const config = optionFn
+        .schema({
+          number: optionFn.number({
+            validate: createValidator<number>(
+              (v) => typeof v === "number" && v > 0,
+              "must be positive",
+            ),
+          }),
+        })
+        .load({ env: false, args: false, files: FILE });
+
+      expect(config.number).toBe(1);
+    });
+  });
+
+  describe("without validate option", () => {
+    it("should not run any validation when validate is not set", () => {
+      const config = optionFn
+        .schema({
+          number: optionFn.number({ defaultValue: -1 }),
+        })
+        .load({ env: false, args: false });
+
+      expect(config.number).toBe(-1);
+    });
+  });
+
+  describe("with loadExtended", () => {
+    it("should report validation warnings alongside other warnings", () => {
+      const config = optionFn
+        .schema({
+          number: optionFn.number({
+            defaultValue: 42,
+            validate: createValidator<number>(
+              (v) => typeof v === "number" && v > 0,
+              "must be positive",
+            ),
+          }),
+        })
+        .loadExtended({ env: false, args: false });
+
+      expect(config.data).toBeDefined();
+      expect(config.warnings).toEqual([]);
+    });
+  });
+
+  describe("with strict mode", () => {
+    it("should include validation errors even in strict mode", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            port: optionFn.number({
+              defaultValue: -1,
+              validate: createValidator<number>(
+                (v) => typeof v === "number" && v > 0,
+                "must be positive",
+              ),
+            }),
+          })
+          .load({ env: false, args: false, strict: true }),
+      );
+
+      const validationErrors = err.errors.filter(
+        (e) => e.kind === "validation",
+      );
+      expect(validationErrors).toHaveLength(1);
+    });
+  });
+
+  describe("skips validation on missing optional values", () => {
+    it("should not validate when optional value is not provided", () => {
+      const neverValidValidator: StandardSchemaV1<string> = {
+        "~standard": {
+          version: 1,
+          vendor: "test",
+          validate() {
+            return { issues: [{ message: "should not be called" }] };
+          },
+        },
+      };
+
+      const config = optionFn
+        .schema({
+          optional: optionFn.string({
+            validate: neverValidValidator,
+          }),
+        })
+        .load({ env: false, args: false });
+
+      // Optional field not provided — validator not invoked, no error
+      expect(config.optional).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add optional `validate` property to all option types (`string`, `number`, `bool`, `array`, `object`) accepting any [Standard Schema v1](https://github.com/standard-schema/standard-schema) implementation
- Validation runs **after** type coercion so validators see final typed values (e.g., number `3000`, not string `"3000"`)
- Inline Standard Schema v1 types — zero new dependencies
- Validation errors surface as `kind: "validation"` in `ConfigLoadError`
- Works with Zod 3.24+, Valibot 1.0+, ArkType 2.1+, or custom validators
- Export `StandardSchemaV1` type for custom validator authors
- 15 new tests (14 validation + 1 coverage for pre-existing uncovered branch)
- Updated README and docs with Validation section and examples

Closes #73

## Test plan

- [ ] All existing tests pass (171 total)
- [ ] Validation passes with valid values
- [ ] Validation fails with `kind: "validation"` errors for invalid values
- [ ] Validation runs after type coercion (env string coerced to number before validation)
- [ ] Multiple validation errors collected across fields
- [ ] Multiple issues from a single validator collected
- [ ] Validation skipped for missing optional values
- [ ] Works with `loadExtended()` and `strict` mode
- [ ] Lint, type-check, and build all pass