### PR TITLE
test: add Zod integration tests for Standard Schema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "tsconfig-paths": "^4.2.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.4",
-    "typescript-eslint": "^8.24.0"
+    "typescript-eslint": "^8.24.0",
+    "zod": "^4.3.6"
   }
 }

--- a/src/option/base.ts
+++ b/src/option/base.ts
@@ -357,6 +357,11 @@ export default class OptionBase<T extends OptionKind = OptionKind> {
     if (valueIsInvalid(value)) return;
 
     const result = validator["~standard"].validate(value);
+    if (result instanceof Promise) {
+      throw new Error(
+        "Async validators are not supported. The validate function must return a synchronous result.",
+      );
+    }
     if ("issues" in result && result.issues) {
       const ident = path.join(".");
       const source =

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,13 +91,17 @@ export class InvalidValue {}
  */
 export interface StandardSchemaIssue {
   message: string;
-  path?: ReadonlyArray<PropertyKey>;
+  path?: ReadonlyArray<PropertyKey | object>;
 }
+
+type StandardSchemaResult<Output> =
+  | { value: Output }
+  | { issues: ReadonlyArray<StandardSchemaIssue> };
 
 /**
  * Minimal Standard Schema v1 interface for value validation.
  * Any object with a `~standard.validate()` method is accepted — this covers
- * Zod 3.24+, Valibot 1.0+, ArkType 2.1+, and custom validators.
+ * Zod 3.24+/4+, Valibot 1.0+, ArkType 2.1+, and custom validators.
  */
 export interface StandardSchemaV1<Output = unknown> {
   "~standard": {
@@ -105,6 +109,6 @@ export interface StandardSchemaV1<Output = unknown> {
     vendor: string;
     validate(
       value: unknown,
-    ): { value: Output } | { issues: ReadonlyArray<StandardSchemaIssue> };
+    ): StandardSchemaResult<Output> | Promise<StandardSchemaResult<Output>>;
   };
 }

--- a/tests/zodValidation.spec.ts
+++ b/tests/zodValidation.spec.ts
@@ -1,0 +1,353 @@
+import { z } from "zod";
+
+import { ConfigLoadError } from "@/errors";
+import optionFn from "@/src";
+
+const FILE = "./tests/__mocks__/fileMock.yaml";
+
+function getLoadError(fn: () => unknown): ConfigLoadError {
+  try {
+    fn();
+  } catch (err) {
+    if (err instanceof ConfigLoadError) return err;
+    throw err;
+  }
+  throw new Error("Expected ConfigLoadError to be thrown");
+}
+
+describe("Zod integration", () => {
+  describe("number validation", () => {
+    it("should pass with a valid port number", () => {
+      const config = optionFn
+        .schema({
+          port: optionFn.number({
+            defaultValue: 3000,
+            validate: z.number().min(1).max(65535),
+          }),
+        })
+        .load({ env: false, args: false });
+
+      expect(config.port).toBe(3000);
+    });
+
+    it("should fail when number is out of range", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            port: optionFn.number({
+              defaultValue: 99999,
+              validate: z.number().min(1).max(65535),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0].kind).toBe("validation");
+      expect(err.errors[0].path).toBe("port");
+    });
+
+    it("should validate an integer constraint", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            count: optionFn.number({
+              defaultValue: 3.14,
+              validate: z.number().int(),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0].kind).toBe("validation");
+    });
+  });
+
+  describe("string validation", () => {
+    it("should pass with a valid email", () => {
+      const config = optionFn
+        .schema({
+          email: optionFn.string({
+            defaultValue: "user@example.com",
+            validate: z.string().email(),
+          }),
+        })
+        .load({ env: false, args: false });
+
+      expect(config.email).toBe("user@example.com");
+    });
+
+    it("should fail with an invalid email", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            email: optionFn.string({
+              defaultValue: "not-an-email",
+              validate: z.string().email(),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0].kind).toBe("validation");
+      expect(err.errors[0].path).toBe("email");
+    });
+
+    it("should validate with z.enum()", () => {
+      const config = optionFn
+        .schema({
+          env: optionFn.string({
+            defaultValue: "production",
+            validate: z.enum(["development", "staging", "production"]),
+          }),
+        })
+        .load({ env: false, args: false });
+
+      expect(config.env).toBe("production");
+    });
+
+    it("should fail with an invalid enum value", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            env: optionFn.string({
+              defaultValue: "invalid",
+              validate: z.enum(["development", "staging", "production"]),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0].kind).toBe("validation");
+    });
+
+    it("should validate a URL", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            url: optionFn.string({
+              defaultValue: "not-a-url",
+              validate: z.string().url(),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0].kind).toBe("validation");
+    });
+
+    it("should validate min/max length", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            token: optionFn.string({
+              defaultValue: "ab",
+              validate: z.string().min(8).max(64),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0].kind).toBe("validation");
+    });
+  });
+
+  describe("boolean validation", () => {
+    it("should pass with a valid boolean", () => {
+      const config = optionFn
+        .schema({
+          debug: optionFn.bool({
+            defaultValue: true,
+            validate: z.boolean(),
+          }),
+        })
+        .load({ env: false, args: false });
+
+      expect(config.debug).toBe(true);
+    });
+  });
+
+  describe("coercion before validation", () => {
+    it("should validate env string as number after coercion", () => {
+      const originalEnv = process.env;
+      process.env = { ...originalEnv, TEST_PORT: "8080" };
+      try {
+        const config = optionFn
+          .schema({
+            port: optionFn.number({
+              env: "TEST_PORT",
+              validate: z.number().min(1).max(65535),
+            }),
+          })
+          .load({ env: true, args: false });
+
+        expect(config.port).toBe(8080);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    it("should fail validation on coerced env value out of range", () => {
+      const originalEnv = process.env;
+      process.env = { ...originalEnv, TEST_PORT: "0" };
+      try {
+        const err = getLoadError(() =>
+          optionFn
+            .schema({
+              port: optionFn.number({
+                env: "TEST_PORT",
+                validate: z.number().min(1),
+              }),
+            })
+            .load({ env: true, args: false }),
+        );
+
+        expect(err.errors).toHaveLength(1);
+        expect(err.errors[0].kind).toBe("validation");
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    it("should validate boolean coerced from env string", () => {
+      const originalEnv = process.env;
+      process.env = { ...originalEnv, TEST_DEBUG: "true" };
+      try {
+        const config = optionFn
+          .schema({
+            debug: optionFn.bool({
+              env: "TEST_DEBUG",
+              validate: z.boolean(),
+            }),
+          })
+          .load({ env: true, args: false });
+
+        expect(config.debug).toBe(true);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+  });
+
+  describe("with file sources", () => {
+    it("should validate values from YAML files", () => {
+      const config = optionFn
+        .schema({
+          string: optionFn.string({
+            validate: z.string().min(1),
+          }),
+          number: optionFn.number({
+            validate: z.number().positive(),
+          }),
+        })
+        .load({ env: false, args: false, files: FILE });
+
+      expect(config.string).toBe("testString");
+      expect(config.number).toBe(1);
+    });
+
+    it("should fail validation on file values", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            string: optionFn.string({
+              validate: z.string().min(100),
+            }),
+          })
+          .load({ env: false, args: false, files: FILE }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0]).toMatchObject({
+        kind: "validation",
+        path: "string",
+        source: FILE,
+      });
+    });
+  });
+
+  describe("multiple fields with validation", () => {
+    it("should collect errors from multiple fields", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            port: optionFn.number({
+              defaultValue: -1,
+              validate: z.number().positive(),
+            }),
+            host: optionFn.string({
+              defaultValue: "",
+              validate: z.string().min(1),
+            }),
+            debug: optionFn.bool({
+              defaultValue: false,
+              validate: z.literal(true),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      const validationErrors = err.errors.filter(
+        (e) => e.kind === "validation",
+      );
+      expect(validationErrors).toHaveLength(3);
+      expect(validationErrors.map((e) => e.path).sort()).toEqual([
+        "debug",
+        "host",
+        "port",
+      ]);
+    });
+  });
+
+  describe("with loadExtended", () => {
+    it("should return data and no warnings when validation passes", () => {
+      const { data, warnings } = optionFn
+        .schema({
+          port: optionFn.number({
+            defaultValue: 3000,
+            validate: z.number().min(1).max(65535),
+          }),
+        })
+        .loadExtended({ env: false, args: false });
+
+      expect(data).toBeDefined();
+      expect(warnings).toEqual([]);
+    });
+  });
+
+  describe("regex validation", () => {
+    it("should validate with a regex pattern", () => {
+      const config = optionFn
+        .schema({
+          version: optionFn.string({
+            defaultValue: "1.2.3",
+            validate: z.string().regex(/^\d+\.\d+\.\d+$/),
+          }),
+        })
+        .load({ env: false, args: false });
+
+      expect(config.version).toBe("1.2.3");
+    });
+
+    it("should fail with an invalid pattern", () => {
+      const err = getLoadError(() =>
+        optionFn
+          .schema({
+            version: optionFn.string({
+              defaultValue: "not-a-version",
+              validate: z.string().regex(/^\d+\.\d+\.\d+$/),
+            }),
+          })
+          .load({ env: false, args: false }),
+      );
+
+      expect(err.errors).toHaveLength(1);
+      expect(err.errors[0].kind).toBe("validation");
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -14276,6 +14276,11 @@ yoctocolors@^2.1.1:
   resolved "https://registry.yarnpkg.com/yoctocolors/-/yoctocolors-2.1.2.tgz#d795f54d173494e7d8db93150cec0ed7f678c83a"
   integrity sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==
 
+zod@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
+
 zwitch@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"


### PR DESCRIPTION
## Summary

- Add Zod 4 as a devDependency to verify real-world Standard Schema compatibility
- 19 integration tests using actual Zod schemas (number range, string email/url/enum/regex, boolean, coercion, file sources, multi-field errors)
- Widen `StandardSchemaV1` types for Zod 4 compatibility: accept `object` in issue paths (Zod `PathSegment`) and `Promise` returns (async-capable libs)
- Throw a clear error if an async validator is used at runtime (config loading is synchronous)

## Test plan

- [ ] All 190 tests pass (171 existing + 19 new Zod integration)
- [ ] Lint, type-check, build all pass
- [ ] Zod schemas work out of the box with `validate` option — no type errors